### PR TITLE
Fix admin search fields and add regression tests for queries

### DIFF
--- a/faq/admin.py
+++ b/faq/admin.py
@@ -8,13 +8,13 @@ from django.utils.html import strip_tags
 class AnswerHelpfulAdmin(admin.ModelAdmin):
     list_display = ("vote", "answer", "user")
     list_filter = ('vote',)
-    search_fields = ['answer', "user"]
+    search_fields = ['answer__answer', "user__username"]
 
 
 class QuestionHelpfulAdmin(admin.ModelAdmin):
     list_display = ("vote", "question", "user")
     list_filter = ('vote',)
-    search_fields = ['question', "user"]
+    search_fields = ['question__question', "user__username"]
 
 
 class AnswerAdminForm(forms.ModelForm):
@@ -43,7 +43,7 @@ class AnswerAdminForm(forms.ModelForm):
 class AnswerAdmin(admin.ModelAdmin):
     list_display = ("answer_", "question", "helpful", "not_helpful",'is_rich_text')
     list_filter = ('helpful', "not_helpful",'is_rich_text')
-    search_fields = ['answer', "question"]
+    search_fields = ['answer', "question__question"]
     readonly_fields = ('helpful', "not_helpful", 'slug','is_rich_text')
     form = AnswerAdminForm
     def answer_(self, obj):
@@ -68,7 +68,7 @@ class CategoryAdmin(admin.ModelAdmin):
 class CommentAdmin(admin.ModelAdmin):
     list_display = ("comment", "question", "user", "post_time")
     list_filter = ('question', "post_time")
-    search_fields = ['comment', "question"]
+    search_fields = ['comment', "question__question"]
 
 
 class QuestionAdmin(admin.ModelAdmin):

--- a/faq/tests.py
+++ b/faq/tests.py
@@ -174,3 +174,46 @@ class VoteanswerTestCase(TestCase):
                 reverse("faq:vote_answer", args=(question.category.slug, question.slug, self.answer.slug)))
 
         self.assertEqual(response.status_code, 302)
+
+
+class AdminSearchFieldsTestCase(TestCase):
+    """Ensure admin search_fields don't attempt icontains on ForeignKey fields and raise FieldError."""
+
+    def setUp(self):
+        from django.contrib import admin as django_admin
+        self.admin = django_admin
+        self.user = User.objects.create_user(username='bob', password='pw', email='bob@example.com')
+        self.superuser = User.objects.create_superuser(username='admin', email='admin@example.com', password='pw')
+        category = models.Category.objects.create(name='cat', _description='desc')
+        self.question = models.Question.objects.create(category=category, question='searchable question')
+        self.answer = models.Answer.objects.create(question=self.question, answer='searchable answer')
+        self.comment = models.FAQComment.objects.create(user=self.user, comment='search comment', question=self.question)
+        self.ans_help = models.AnswerHelpful.objects.create(user=self.user, answer=self.answer, vote=True)
+        self.q_help = models.QuestionHelpful.objects.create(user=self.user, question=self.question, vote=True)
+        self.request = RequestFactory().get('/admin/')
+        self.request.user = self.superuser
+
+    def _get_results(self, admin_class, model, term):
+        admin_inst = admin_class(model, self.admin.site)
+        qs = model.objects.all()
+        return admin_inst.get_search_results(self.request, qs, term)
+
+    def test_answer_helpful_admin_search_fields_valid(self):
+        from faq.admin import AnswerHelpfulAdmin
+        results, _ = self._get_results(AnswerHelpfulAdmin, models.AnswerHelpful, 'searchable')
+        self.assertTrue(results.exists())
+
+    def test_question_helpful_admin_search_fields_valid(self):
+        from faq.admin import QuestionHelpfulAdmin
+        results, _ = self._get_results(QuestionHelpfulAdmin, models.QuestionHelpful, 'searchable')
+        self.assertTrue(results.exists())
+
+    def test_comment_admin_search_fields_valid(self):
+        from faq.admin import CommentAdmin
+        results, _ = self._get_results(CommentAdmin, models.FAQComment, 'search')
+        self.assertTrue(results.exists())
+
+    def test_answer_admin_search_fields_valid(self):
+        from faq.admin import AnswerAdmin
+        results, _ = self._get_results(AnswerAdmin, models.Answer, 'searchable')
+        self.assertTrue(results.exists())


### PR DESCRIPTION
This pull request Fixes #28 the Django admin search functionality for several FAQ-related models to ensure that searching on related fields works correctly and avoids errors. It also adds comprehensive tests to verify that the admin search fields are correctly configured and do not raise exceptions when searching on ForeignKey fields.

**Admin search field improvements:**

* Updated `search_fields` in `AnswerHelpfulAdmin`, `QuestionHelpfulAdmin`, `AnswerAdmin`, and `CommentAdmin` to use related field lookups (e.g., `'answer__answer'`, `'question__question'`, `'user__username'`) instead of direct ForeignKey fields, preventing `FieldError` when performing searches in the admin. [[1]](diffhunk://#diff-c323eb7c695f30f1c742f8f1f1a7a0dd6758a2aa3f2f1ff4b8c780f032c3f09fL11-R17) [[2]](diffhunk://#diff-c323eb7c695f30f1c742f8f1f1a7a0dd6758a2aa3f2f1ff4b8c780f032c3f09fL46-R46) [[3]](diffhunk://#diff-c323eb7c695f30f1c742f8f1f1a7a0dd6758a2aa3f2f1ff4b8c780f032c3f09fL71-R71)

**Testing enhancements:**

* Added a new `AdminSearchFieldsTestCase` in `faq/tests.py` to verify that the updated admin search fields work as expected and do not raise errors, covering all affected admin classes.