### PR TITLE
Expand CI matrix for Python and Django versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.9", "3.12", "3.14"]
+        python-version: ["3.10", "3.12", "3.14"]
         django-version: ["6.0.*", "5.2.*", "5.1.*"]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,26 +8,28 @@ on:
 
 jobs:
   build:
+    name: Build/Test (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }})
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9", "3.12", "3.14"]
+        django-version: ["6.0.*", "5.2.*", "5.1.*"]
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }} & Django ${{ matrix.django-version }}
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Set env
+      - name: Set env (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }})
         run: echo "RELEASE_VERSION=0.0.1" >> $GITHUB_ENV
-      - name: Install Dependencies
+      - name: Install Dependencies (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }})
         run: |
           pip install django-tinymce
-          pip install Django
+          pip install "Django==${{ matrix.django-version }}"
           pip install -e .
-      - name: Run Tests
+      - name: Run Tests (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }})
         run: |
           cd example
           python manage.py test faq

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ["3.10", "3.12", "3.14"]
-        django-version: ["6.0.*", "5.2.*", "5.1.*"]
+        django-version: ["6.0", "5.2", "5.1"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.10", "3.12", "3.14"]
+        python-version: ["3.11", "3.12", "3.14"]
         django-version: ["6.0", "5.2", "5.1"]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,18 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.11", "3.12", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.14"]
         django-version: ["6.0", "5.2", "5.1"]
+        exclude:
+          # Django 5.1 does not support Python 3.14 (support was added in 5.2)
+          - django-version: "5.1"
+            python-version: "3.14"
+
+          # Django 6.0 dropped support for Python 3.10 and 3.11 (requires 3.12+)
+          - django-version: "6.0"
+            python-version: "3.10"
+          - django-version: "6.0"
+            python-version: "3.11"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for testing to add support for multiple Django versions and an additional Python version. The changes improve the test coverage matrix and make job names more descriptive.

**CI/CD matrix expansion:**

* Added Django version matrix to test against Django 6.0.*, 5.2.*, and 5.1.* in addition to the existing Python versions.
* Added Python 3.14 to the test matrix, ensuring compatibility with the latest Python release.

**Workflow improvements:**

* Updated job and step names to include both Python and Django versions for clearer build logs.
* Changed dependency installation to use the specific Django version from the matrix.